### PR TITLE
[docs] update drastic fork to trngaje from steward-fu

### DIFF
--- a/systems/handheld/nds.md
+++ b/systems/handheld/nds.md
@@ -19,7 +19,6 @@ has_toc: false
 
 | Button             | Action             |
 |:-------------------|:-------------------|
-| F+Select           | `???` |
 | F+Start            | Quit Drastic |
 | F+X                | Main Drastic Menu |
 | F+B                | Change Pixel/Blur Filter |


### PR DESCRIPTION
Updates the docs to mention trngaje fork of DraStic instead of steward-fu, as that is what comes with PIXIE (latest stable muOS release at the time of this PR). Also updates the keymaps to what is the current default.