### PR TITLE
Update install.md for broken link in install guide to goose download

### DIFF
--- a/installation/install.md
+++ b/installation/install.md
@@ -9,7 +9,7 @@ has_children: false
 
 # Download
 
-[Latest](../release/current/goose){: .btn .btn-primary .fs-5 .mb-4 .mb-md-0 .mr-2 .text-grey-dk-300 }
+[Latest](/release/current/goose){: .btn .btn-primary .fs-5 .mb-4 .mb-md-0 .mr-2 .text-grey-dk-300 }
 
 {: .note }
 > Always ensure you download from our official download page or supported mirrors!


### PR DESCRIPTION
link needs to be up one level, user posted broken link in discord:
https://discord.com/channels/1152022492001603615/1180080911434399744/1411888534981181520

I don't have a good way to test this change, but with my rudimentary MD skills and better understanding of linux paths, I think this should be the ticket 