### PR TITLE
Add dedicated SFTP Client documentation (that points out port 2022)

### DIFF
--- a/web/sftpclient.md
+++ b/web/sftpclient.md
@@ -1,0 +1,53 @@
+---
+layout: default
+title: SFTP Client
+permalink: /web/sftpclient
+parent: Web Services
+nav_enabled: true
+has_children: false
+has_toc: false
+---
+
+## How to use an SFTP Client to connect to muos on your device
+
+## General Idea
+This guide will help you enable the SFTP service on your device and connect using a dedicated SFTP client (such as WinSCP, FileZilla, or Cyberduck).
+
+### Prerequisites
+* You are familiar with your SFTP client of choice.
+* Your handheld and your PC are on the same local network (e.g., 192.168.1.x).
+* Wi-Fi is enabled and connected on your muOS device.
+
+---
+
+## Steps
+
+### 1. Enable Services and Note IP
+1. On your device, navigate to **Configuration**.
+2. Select **Webservices**.
+3. Toggle **SFTP + Filebrowser** to enabled.
+4. Note your device's **IP Address** displayed in the Wi-Fi settings or the Webservices menu.
+
+### 2. Configure Your SFTP Client
+Open your client on your PC and enter the following credentials:
+
+| Setting  | Value |
+| :--- | :--- |
+| **Host / IP** | `<Your Device IP>` |
+| **Port** | **2022** |
+| **Protocol** | SFTP (SSH File Transfer Protocol) |
+| **Username** | `muos` |
+| **Password** | `muos` |
+
+> **Note:** The port **2022** is mandatory. Standard SFTP usually defaults to port 22, so you must manually change this.
+
+### 3. Understanding the File Structure
+Once connected, you will see the following directories:
+
+* **MUX:** Internal system files (avoid modifying these).
+* **MMC:** SD1 - contains saves, ROMs, and BIOS.
+* **SDCARD:** SD2 - secondary storage (recommended for most users).
+* **USB:** Any externally connected storage devices.
+
+## Further Assistance
+For further assistance, please refer to the [muOS Discord](https://discord.gg/muos).


### PR DESCRIPTION
I was trying to connect to muos via a sftp client but found that the port wasn't the default 22.  I found a helpful reddit post that pointed out the port needed to be 2022. The documentation doesn't seem to point out the port so I figured I could add it.

Reddit link: [https://www.reddit.com/r/RG35XX_H/comments/1d0l6p0/comment/lsi3p38/](https://www.reddit.com/r/RG35XX_H/comments/1d0l6p0/comment/lsi3p38/)

I didn't want to crowd the existing documentation page for SFTP + FileBrowser - but honestly this content could easily fit there too.

Changes in this PR:
- Created sftpclient.md under the Web Services category.
- Clearly defined the connection parameters (IP, Port, Username, Password).
- Highlighted Port 2022 as the mandatory port for successful connection.
- Maintained consistent styling and structure with the existing documentation.

Appreciate all your guys work. Thanks.